### PR TITLE
changes broken SQL command links:

### DIFF
--- a/src/main/asciidoc/appendix/settings.adoc
+++ b/src/main/asciidoc/appendix/settings.adoc
@@ -42,7 +42,7 @@ java ... -Darcadedb.bucketDefaultPageSize=1048576 ...
 [[Settings-SQL]]
 ==== SQL (Database Level)
 
-All the changes executed via <<_sql-alter-database,SQL Alter Database>> command are relative to the current database only and are persistent.
+All the changes executed via <<SQL-Alter-Database,SQL Alter Database>> command are relative to the current database only and are persistent.
 Example to increase the default page size for buckets to 1 MB:
 
 ```sql

--- a/src/main/asciidoc/sql/SQL-Alter-Database.adoc
+++ b/src/main/asciidoc/sql/SQL-Alter-Database.adoc
@@ -1,3 +1,4 @@
+[[SQL-Alter-Database]]
 [discrete]
 
 === SQL - `ALTER DATABASE`

--- a/src/main/asciidoc/sql/SQL-Alter-Property.adoc
+++ b/src/main/asciidoc/sql/SQL-Alter-Property.adoc
@@ -1,3 +1,4 @@
+[[SQL-Alter-Property]]
 [discrete]
 
 === SQL - `ALTER PROPERTY`
@@ -41,5 +42,5 @@ ArcadeDB> ALTER PROPERTY User.createdOn READONLY true
 
 For more information, see:
 
-* <<_sql-create-type,`CREATE PROPERTY`>>
-* <<_sql-drop-property,`DROP PROPERTY`>>
+* <<SQL-Create-Property,`CREATE PROPERTY`>>
+* <<SQL-Drop-Property,`DROP PROPERTY`>>

--- a/src/main/asciidoc/sql/SQL-Alter-Type.adoc
+++ b/src/main/asciidoc/sql/SQL-Alter-Type.adoc
@@ -1,3 +1,4 @@
+[[SQL-Alter-Type]]
 [discrete]
 
 === SQL - `ALTER TYPE`

--- a/src/main/asciidoc/sql/SQL-Backup-Database.adoc
+++ b/src/main/asciidoc/sql/SQL-Backup-Database.adoc
@@ -1,3 +1,4 @@
+[[SQL-Backup-Database]]
 [discrete]
 === SQL - `BACKUP DATABASE`
 

--- a/src/main/asciidoc/sql/SQL-Create-Bucket.adoc
+++ b/src/main/asciidoc/sql/SQL-Create-Bucket.adoc
@@ -1,3 +1,4 @@
+[[SQL-Create-Bucket]]
 [discrete]
 
 === SQL - `CREATE BUCKET`

--- a/src/main/asciidoc/sql/SQL-Create-Edge.adoc
+++ b/src/main/asciidoc/sql/SQL-Create-Edge.adoc
@@ -1,3 +1,4 @@
+[[SQL-Create-Edge]]
 [discrete]
 
 === SQL - `CREATE EDGE`

--- a/src/main/asciidoc/sql/SQL-Create-Index.adoc
+++ b/src/main/asciidoc/sql/SQL-Create-Index.adoc
@@ -1,3 +1,4 @@
+[[SQL-Create-Index]]
 [discrete]
 
 === SQL - `CREATE INDEX`

--- a/src/main/asciidoc/sql/SQL-Create-Property.adoc
+++ b/src/main/asciidoc/sql/SQL-Create-Property.adoc
@@ -1,3 +1,4 @@
+[[SQL-Create-Property]]
 [discrete]
 
 === SQL - `CREATE PROPERTY`

--- a/src/main/asciidoc/sql/SQL-Create-Type.adoc
+++ b/src/main/asciidoc/sql/SQL-Create-Type.adoc
@@ -1,3 +1,4 @@
+[[SQL-Create-Type]]
 [discrete]
 === SQL - `CREATE TYPE`
 

--- a/src/main/asciidoc/sql/SQL-Create-Vertex.adoc
+++ b/src/main/asciidoc/sql/SQL-Create-Vertex.adoc
@@ -1,3 +1,4 @@
+[[SQL-Create-Vertex]]
 [discrete]
 
 === SQL - `CREATE VERTEX`

--- a/src/main/asciidoc/sql/SQL-Delete.adoc
+++ b/src/main/asciidoc/sql/SQL-Delete.adoc
@@ -1,9 +1,10 @@
+[[SQL-Delete]]
 [discrete]
 === SQL - `DELETE`
 
 image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/main/src/main/asciidoc/sql/SQL-Delete.adoc" float=right]
 
-Removes one or more records from the database. You can refine the set of records that it removes using the <<_filtering,`WHERE`>> clause.
+Removes one or more records from the database. You can refine the set of records that it removes using the <<Filtering,`WHERE`>> clause.
 
 *Syntax:*
 
@@ -17,7 +18,7 @@ DELETE FROM <Type>|BUCKET:<bucket>|INDEX:<index> [RETURN <returning>]
 * *`RETURN`* Defines what values the database returns. It takes one of the following values:
 * `COUNT` Returns the number of deleted records. This is the default option.
 * `BEFORE` Returns the number of records before the removal.
-* *<<_filtering,`WHERE`>>* Filters to the records you want to delete.
+* *<<Filtering,`WHERE`>>* Filters to the records you want to delete.
 * *`LIMIT`* Defines the maximum number of records to delete.
 * *`TIMEOUT`* Defines the time period to allow the operation to run, before it times out.
 * *`UNSAFE`* Allows for the processing of a DELETE on a Vertex or an Edge, without an exception error. It is not recommended to use this! If you must delete an Edge or a Vertex, use the corresponding commands DELETE EDGE or DELETE VERTEX.

--- a/src/main/asciidoc/sql/SQL-Drop-Bucket.adoc
+++ b/src/main/asciidoc/sql/SQL-Drop-Bucket.adoc
@@ -1,3 +1,4 @@
+[[SQL-Drop-Bucket]]
 [discrete]
 === SQL - `DROP BUCKET`
 
@@ -27,5 +28,4 @@ ArcadeDB> DROP BUCKET Account
 For more information, see:
 
 * <<SQL-Create-Bucket,`CREATE BUCKET`>>
-* <<SQL-Alter-Bucket,`ALTER BUCKET`>>
 * <<SQL-Drop-Type,`DROP TYPE`>>

--- a/src/main/asciidoc/sql/SQL-Drop-Index.adoc
+++ b/src/main/asciidoc/sql/SQL-Drop-Index.adoc
@@ -1,3 +1,4 @@
+[[SQL-Drop-Index]]
 [discrete]
 
 === SQL - `DROP INDEX`

--- a/src/main/asciidoc/sql/SQL-Drop-Property.adoc
+++ b/src/main/asciidoc/sql/SQL-Drop-Property.adoc
@@ -1,3 +1,4 @@
+[[SQL-Drop-Property]]
 [discrete]
 
 === SQL - `DROP PROPERTY`

--- a/src/main/asciidoc/sql/SQL-Drop-Type.adoc
+++ b/src/main/asciidoc/sql/SQL-Drop-Type.adoc
@@ -1,3 +1,4 @@
+[[SQL-Drop-Type]]
 [discrete]
 
 === SQL - `DROP TYPE`
@@ -32,4 +33,3 @@ For more information, see:
 
 * <<SQL-Create-Type,`CREATE TYPE`>>
 * <<SQL-Alter-Type,`ALTER TYPE`>>
-* <<SQL-Alter-Bucket,`ALTER BUCKET`>>

--- a/src/main/asciidoc/sql/SQL-Explain.adoc
+++ b/src/main/asciidoc/sql/SQL-Explain.adoc
@@ -1,3 +1,4 @@
+[[SQL-Explain]]
 [discrete]
 
 === SQL - `EXPLAIN`

--- a/src/main/asciidoc/sql/SQL-Insert.adoc
+++ b/src/main/asciidoc/sql/SQL-Insert.adoc
@@ -1,3 +1,4 @@
+[[SQL-Insert]]
 [discrete]
 
 === SQL - `INSERT`
@@ -108,7 +109,7 @@ In the ArcadeDB abbreviated syntax:
 ArcadeDB> INSERT INTO Profiles SET name = 'Luca', friends = [#10:3, #10:4]
 ----
 
-* Inserts using <<SQL-Query,`SELECT`>> sub-queries
+* Inserts using <<SQL-Select,`SELECT`>> sub-queries
 [source,sql]
 ----
 ArcadeDB> INSERT INTO Diver SET name = 'Luca', buddy = (SELECT FROM Diver 

--- a/src/main/asciidoc/sql/SQL-Introduction.adoc
+++ b/src/main/asciidoc/sql/SQL-Introduction.adoc
@@ -7,7 +7,7 @@ image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/
 When it comes to query languages, SQL is the most widely recognized standard. The majority of developers have experience and are
 comfortable with SQL. For this reason ArcadeDB uses SQL as its query language and adds some extensions to enable graph
 functionality. There are a few differences between the standard SQL syntax and that supported by ArcadeDB, but for the most part, it
-should feel very natural. The differences are covered in the <<ArcadeDB SQL dialect,ArcadeDB-sql-dialect>> section of this page.
+should feel very natural. The differences are covered in the <<SQL-Syntax,ArcadeDB SQL dialect>> section of this page.
 
 If you are looking for the most efficient way to traverse a graph, we suggest using the <<SQL-Match,SQL-MATCH>> instead.
 
@@ -56,13 +56,13 @@ SELECT FROM INDEX:myIndex WHERE key = 'Jay'
 *Extra resources*
 
 * <<SQL-Syntax,Syntax>>
-* <<_projections,Projections>>
-* <<_filtering,Conditions>>
-* <<_filtering,Where clause>>
+* <<SQL-Projections,Projections>>
+* <<Filtering,Conditions>>
+* <<Filtering,Where clause>>
 * <<_filtering-operators,Operators>>
-* <<_pagination,Pagination>>
+* <<SQL-Pagination,Pagination>>
 * <<_sql-batch,Batch>>
-* <<_sql-match,Match>> for traversing graphs
+* <<SQL-Match,Match>> for traversing graphs
 
 *ArcadeDB SQL dialect*
 
@@ -141,7 +141,7 @@ In ArcadeDB, the `*` is optional:
 SELECT FROM Customer
 ----
 
-See <<SQL projections,SQL-Projections>>.
+See <<SQL-Projections,SQL projections>>.
 
 *DISTINCT*
 

--- a/src/main/asciidoc/sql/SQL-Match.adoc
+++ b/src/main/asciidoc/sql/SQL-Match.adoc
@@ -1,3 +1,4 @@
+[[SQL-Match]]
 [discrete]
 
 === SQL - `MATCH`
@@ -53,7 +54,7 @@ LIMIT <number>
 
 * *`&lt;type&gt;`* Defines a valid target type.
 * *`as: &lt;alias&gt;`* Defines an alias for a node in the pattern.
-* *`&lt;whereCondition&gt;`* Defines a filter condition to match a node in the pattern. It supports the normal SQL <<SQL-Where,`WHERE`>> clause. You can also use the `$currentMatch` and `$matched` &lt;&lt;context variables,#context-variables).
+* *`&lt;whereCondition&gt;`* Defines a filter condition to match a node in the pattern. It supports the normal SQL <<Filtering,`WHERE`>> clause. You can also use the `$currentMatch` and `$matched` &lt;&lt;context variables,#context-variables).
 * *`&lt;functionName&gt;`* Defines a graph function to represent the connection between two nodes. For instance, `out()`, `in()`, `outE()`, `inE()`, etc.
 For out(), in(), both() also a shortened _arrow_ syntax is supported:
 * `{...}.out(){...}` can be written as `{...}--&gt;{...}`
@@ -62,7 +63,7 @@ For out(), in(), both() also a shortened _arrow_ syntax is supported:
 * `{...}.in(&quot;EdgeType&quot;){...}` can be written as `{...}&lt;-EdgeType-{...}`
 * `{...}.both(){...}` can be written as `{...}--{...}`
 * `{...}.both(&quot;EdgeType&quot;){...}` can be written as `{...}-EdgeType-{...}`
-* *`&lt;whileCondition&gt;`* Defines a condition that the statement must meet to allow the traversal of this path. It supports the normal SQL <<SQL-Where,`WHERE`>> clause. You can also use the `$currentMatch`, `$matched` and `$depth` &lt;&lt;context variables,#context-variables). For more information, see &lt;&lt;Deep Traversal While Condition,#deep-traversal), below.
+* *`&lt;whileCondition&gt;`* Defines a condition that the statement must meet to allow the traversal of this path. It supports the normal SQL <<Filtering,`WHERE`>> clause. You can also use the `$currentMatch`, `$matched` and `$depth` &lt;&lt;context variables,#context-variables). For more information, see &lt;&lt;Deep Traversal While Condition,#deep-traversal), below.
 * *`&lt;maxDepth&gt;`* Defines the maximum depth for this single path.
 * *`&lt;depthAlias&gt;`* This is valid only if you have a `while` or a `maxDepth`. It defines the alias to be used to store the depth of this traversal. This alias can be used in the `RETURN` block to retrieve the depth of current traversal.
 * *`&lt;pathAlias&gt;`* This is valid only if you have a `while` or a `maxDepth`. It defines the alias to be used to store the elements traversed to reach this alias. This alias can be used in the `RETURN` block to retrieve the elements traversed to reach this alias.
@@ -297,7 +298,7 @@ When running these queries, you can use any of the following context variables:
 
 *Expanding Attributes*
 
-You can run this statement as a sub-query inside of another statement. Doing this allows you to obtain details and aggregate data from the inner <<SQL-Query,`SELECT`>> query.
+You can run this statement as a sub-query inside of another statement. Doing this allows you to obtain details and aggregate data from the inner <<SQL-Select,`SELECT`>> query.
 
 [source,sql]
 ----
@@ -454,9 +455,9 @@ ArcadeDB> MATCH {type: Person, where: (name = 'a')}.out("Parent")
 
 *Best practices*
 
-Queries can involve multiple operations, based on the domain model and use case. In some cases, like projection and aggregation, you can easily manage them with a <<SQL-Query,`SELECT`>> query. With others, such as pattern matching and deep traversal, <<SQL-Match,`MATCH`>> statements are more appropriate.
+Queries can involve multiple operations, based on the domain model and use case. In some cases, like projection and aggregation, you can easily manage them with a <<SQL-Select,`SELECT`>> query. With others, such as pattern matching and deep traversal, <<SQL-Match,`MATCH`>> statements are more appropriate.
 
-Use <<SQL-Query,`SELECT`>> and <<SQL-Match,`MATCH`>> statements together (that is, through sub-queries), to give each statement the correct responsibilities. Here,
+Use <<SQL-Select,`SELECT`>> and <<SQL-Match,`MATCH`>> statements together (that is, through sub-queries), to give each statement the correct responsibilities. Here,
 
 *Filtering Record Attributes for a Single Type*
 
@@ -475,13 +476,13 @@ ArcadeDB> MATCH {type: Person, as: person, where: (name = 'John')}
           RETURN person
 ----
 
-The efficiency remains the same. Both queries use an index. With <<SQL-Query,`SELECT`>>, you obtain expanded records, while with <<SQL-Match,`MATCH`>>, you only obtain the Record ID's.
+The efficiency remains the same. Both queries use an index. With <<SQL-Select,`SELECT`>>, you obtain expanded records, while with <<SQL-Match,`MATCH`>>, you only obtain the Record ID's.
 
 *Filtering on Record Attributes of Connected Elements*
 
-Filtering based on the record attributes of connected elements, such as neighboring vertices, can grow trick when using <<SQL-Query,`SELECT`>>, while with <<SQL-Match,`MATCH`>> it is simple.
+Filtering based on the record attributes of connected elements, such as neighboring vertices, can grow trick when using <<SQL-Select,`SELECT`>>, while with <<SQL-Match,`MATCH`>> it is simple.
 
-For instance, find all people living in Rome that have a friend called John. There are three different ways you can write this, using <<SQL-Query,`SELECT`>>:
+For instance, find all people living in Rome that have a friend called John. There are three different ways you can write this, using <<SQL-Select,`SELECT`>>:
 
 ----
 ArcadeDB> SELECT FROM Person WHERE BOTH('Friend').name CONTAINS 'John'
@@ -505,7 +506,7 @@ ArcadeDB> MATCH {type: Person, where: (name = 'John')}.both("Friend")
 		  RETURN result
 ----
 
-Here, the query executor optimizes the query for you, choosing indexes where they exist. Moreover, the query becomes more readable, especially in complex cases, such as multiple nested <<SQL-Query,`SELECT`>> queries.
+Here, the query executor optimizes the query for you, choosing indexes where they exist. Moreover, the query becomes more readable, especially in complex cases, such as multiple nested <<SQL-Select,`SELECT`>> queries.
 
 *`TRAVERSE` Alternative*
 
@@ -546,7 +547,7 @@ ArcadeDB> MATCH {type: Person, where: (name = 'John')}.(bothE("Friend")
 
 *Projections and Grouping Operations*
 
-Projections and grouping operations are better expressed with a <<SQL-Query,`SELECT`>> query. If you need to filter and do projection or aggregation in the same query, you can use <<SQL-Query,`SELECT`>> and <<SQL-Match,`MATCH`>> in the same statement.
+Projections and grouping operations are better expressed with a <<SQL-Select,`SELECT`>> query. If you need to filter and do projection or aggregation in the same query, you can use <<SQL-Select,`SELECT`>> and <<SQL-Match,`MATCH`>> in the same statement.
 
 This is particular important when you expect a result that contains attributes from different connected records (cartesian product). For instance, to retrieve names, their friends and the date since they became friends:
 

--- a/src/main/asciidoc/sql/SQL-Pagination.adoc
+++ b/src/main/asciidoc/sql/SQL-Pagination.adoc
@@ -1,3 +1,4 @@
+[[SQL-Pagination]]
 [discrete]
 === Pagination
 

--- a/src/main/asciidoc/sql/SQL-Profile.adoc
+++ b/src/main/asciidoc/sql/SQL-Profile.adoc
@@ -1,3 +1,4 @@
+[[SQL-Profile]]
 [discrete]
 
 === SQL - `PROFILE`
@@ -7,7 +8,7 @@ image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/
 PROFILE SQL command returns information about query execution planning and statistics for a specific statement.
 The statement is actually executed to provide the execution stats.
 
-The result is the execution plan of the query (like for <<EXPLAIN,SQL-Explain>> ) with additional information about execution time spent on each step, in microseconds.
+The result is the execution plan of the query (like for <<SQL-Explain,EXPLAIN>> ) with additional information about execution time spent on each step, in microseconds.
 
 *Syntax*
 

--- a/src/main/asciidoc/sql/SQL-Projections.adoc
+++ b/src/main/asciidoc/sql/SQL-Projections.adoc
@@ -1,3 +1,4 @@
+[[SQL-Projections]]
 [discrete]
 
 === Projections
@@ -28,8 +29,8 @@ has three projections:
 
 `&lt;expression&gt; [&lt;nestedProjection&gt;] [ AS &lt;alias&gt; ]`
 
-* `&lt;expression&gt;` is an expression (see <<SQL Syntax,SQL-Syntax>>) that represents the way to calculate the value of the single projection
-* `&lt;alias&gt;` is the Identifier (see <<SQL Syntax,SQL-Syntax>>) representing the field name used to return the value in the result set
+* `&lt;expression&gt;` is an expression (see <<SQL-Syntax,SQL Syntax>>) that represents the way to calculate the value of the single projection
+* `&lt;alias&gt;` is the Identifier (see <<SQL-Syntax,SQL Syntax>>) representing the field name used to return the value in the result set
 
 A projection block has the following syntax:
 

--- a/src/main/asciidoc/sql/SQL-Select-Execution.adoc
+++ b/src/main/asciidoc/sql/SQL-Select-Execution.adoc
@@ -137,7 +137,7 @@ The typical execution plan is made of the following steps:
 
 Obviously, a simple query like `SELECT FROM Person` will have a very simple execution plan made of a single step (the fetch from `Person` type), while a complex query will have an execution plan made of multiple steps
 
-To display the execution plan of a query, without executing it, you can just execute the query prefixing it with `EXPLAIN`, eg.
+To display the execution plan of a query, without executing it, you can just execute the query prefixing it with <<SQL-Explain,`EXPLAIN`>>, eg.
 
 [source,sql]
 ----

--- a/src/main/asciidoc/sql/SQL-Select.adoc
+++ b/src/main/asciidoc/sql/SQL-Select.adoc
@@ -23,7 +23,7 @@ SELECT [ <Projections> ] [ FROM <Target> [ LET <Assignment>* ] ]
 
 ----
 
-* *<<_projections,`Projections`>>* Indicates the data you want to extract from the query as the result-set. Note: In
+* *<<SQL-Projections,`Projections`>>* Indicates the data you want to extract from the query as the result-set. Note: In
  ArcadeDB, this variable is optional. In the projections you can define aliases for single fields, using the `AS` keyword; in
  current release aliases cannot be used in the WHERE condition, GROUP BY and ORDER BY (they will be evaluated to null)
 * *`FROM`* Designates the object to query. This can be a type, bucket, single <<RID,RID>>, set of <<RID,RID>> index values sorted
@@ -40,17 +40,16 @@ SELECT [ <Projections> ] [ FROM <Target> [ LET <Assignment>* ] ]
 ** When querying indexes, use the following prefixes:
 *** `INDEXVALUES:&lt;index&gt;` and `INDEXVALUESASC:&lt;index&gt;` sorts values into an ascending order of index keys.
 *** `INDEXVALUESDESC:&lt;index&gt;` sorts the values into a descending order of index keys.
-* *<<_filtering,`WHERE`>>* Designates conditions to filter the result-set.
+* *<<Filtering,`WHERE`>>* Designates conditions to filter the result-set.
 * *<<_let-block,`LET`>>* Binds context variables to use in projections, conditions or sub-queries.
 * *`GROUP BY`* Designates field on which to group the result-set.
 * *`ORDER BY`* Designates the field with which to order the result-set. Use the optional `ASC` and `DESC` operators to define the
  direction of the order. The default is ascending. Additionally, if you are using a &lt;&lt;projection,SQL-Query.md#projections), you
  need to include the `ORDER BY` field in the projection. Note that ORDER BY works only on projection fields (fields that are
  returned to the result set) not on LET variables.
-* *<<_sql-select-unwinding,`UNWIND`>>* Designates the field on which to unwind the collection.
-* *`SKIP`* Defines the number of records you want to skip from the start of the result-set. You may find this useful in <<
- pagination,Pagination>>, when using it in conjunction with `LIMIT`.
-* *`LIMIT`* Defines the maximum number of records in the result-set. You may find this useful in <<pagination,Pagination>>, when
+* *<<SQL-Select-Unwind,`UNWIND`>>* Designates the field on which to unwind the collection.
+* *`SKIP`* Defines the number of records you want to skip from the start of the result-set. You may find this useful in <<SQL-Pagination,Pagination>>, when using it in conjunction with `LIMIT`.
+* *`LIMIT`* Defines the maximum number of records in the result-set. You may find this useful in <<SQL-Pagination,Pagination>>, when
  using it in conjunction with `SKIP`.
 * *`TIMEOUT`* Defines the maximum time in milliseconds for the query. By default, queries have no timeouts. If you don't specify a
  timeout strategy, it defaults to `EXCEPTION`. These are the available timeout strategies:
@@ -266,6 +265,7 @@ ArcadeDB> SELECT $temp.name FROM Profile LET $temp = address.city WHERE $city.na
           $city.country.name = 'France' )
 ----
 
+[[SQL-Select-Unwind]]
 [discrete]
 ==== Unwinding
 

--- a/src/main/asciidoc/sql/SQL-Traverse.adoc
+++ b/src/main/asciidoc/sql/SQL-Traverse.adoc
@@ -1,3 +1,4 @@
+[[SQL-Traverse]]
 [discrete]
 
 === SQL - `TRAVERSE`
@@ -6,7 +7,7 @@ image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/
 
 Retrieves connected records crossing relationships. This works with both the Document and Graph API's, meaning that you can traverse relationships between say invoices and customers on a graph, without the need to model the domain using the Graph API.
 
-NOTE: In many cases, you may find it more efficient to use <<SQL-Query,`SELECT`>>, which can result in shorter and faster queries. For more information, see &lt;&lt;traverse-versus-select,`TRAVERSE` versus `SELECT`) below.
+NOTE: In many cases, you may find it more efficient to use <<SQL-Select,`SELECT`>>, which can result in shorter and faster queries. For more information, see &lt;&lt;traverse-versus-select,`TRAVERSE` versus `SELECT`) below.
 
 *Syntax*
 
@@ -31,7 +32,7 @@ TRAVERSE [<type.]field>|*|any()|all()
 * *`LIMIT`* Defines the maximum number of results the command can return.
 * <<_traversal-strategies,`STRATEGY`>> Defines strategy for traversing the graph.
 
-NOTE: The use of the <<SQL-Where,`WHERE`>> clause has been deprecated for this command.
+NOTE: The use of the <<Filtering,`WHERE`>> clause has been deprecated for this command.
 
 NOTE: There is a difference between `MAXDEPTH N` and `WHILE DEPTH &lt;= N`: the `MAXDEPTH` will evaluate exactly N levels, while the `WHILE` will evaluate N+1 levels and will discard the N+1th, so the `MAXDEPTH` in general has better performance.
 
@@ -59,9 +60,9 @@ ArcadeDB> SELECT FROM (TRAVERSE out("Friend") FROM #10:1234 MAXDEPTH 3)
             WHERE $depth >= 1
 ----
 
-NOTE: You can also define the maximum depth in the <<SQL-Query,`SELECT`>> command, but it's much more efficient to set it at the inner <<SQL-Traverse,`TRAVERSE`>> statement because the returning record sets are already filtered by depth.
+NOTE: You can also define the maximum depth in the <<SQL-Select,`SELECT`>> command, but it's much more efficient to set it at the inner <<SQL-Traverse,`TRAVERSE`>> statement because the returning record sets are already filtered by depth.
 
-* Combine traversal with <<SQL-Query,`SELECT`>> command to filter the result-set. Repeat the above example, filtering for users in Rome:
+* Combine traversal with <<SQL-Select,`SELECT`>> command to filter the result-set. Repeat the above example, filtering for users in Rome:
 [source,sql]
 ----
 ArcadeDB> SELECT FROM (TRAVERSE out("Friend") FROM #10:1234 MAXDEPTH 3) 
@@ -108,7 +109,7 @@ In addition to the above, you can use the following context variables in travers
 * *`$parent`* Gives the parent context, if any. You may find this useful when traversing from a sub-query.
 * *`$current`* Gives the current record in the iteration. To get the upper-level record in nested queries, you can use `$parent.$current`.
 * *`$depth`* Gives the current depth of nesting.
-* *`$path`* Gives a string representation of the current path. For instance, `#5:0.out`. You can also display it through <<_sql__select,`SELECT`>>:
+* *`$path`* Gives a string representation of the current path. For instance, `#5:0.out`. You can also display it through <<SQL-Select,`SELECT`>>:
 [source,sql]
 ----
 ArcadeDB> SELECT $path FROM (TRAVERSE * FROM V)
@@ -119,7 +120,7 @@ ArcadeDB> SELECT $path FROM (TRAVERSE * FROM V)
 link:./traverse-versus-select.html[traverse-versus-select]
 *`TRAVERSE` versus `SELECT`*
 
-When you already know traversal information, such as relationship names and depth-level, consider using <<_sql__select,`SELECT`>> instead of <<_sql__traverse_,`TRAVERSE`>> as it is faster in some cases.
+When you already know traversal information, such as relationship names and depth-level, consider using <<SQL-Select,`SELECT`>> instead of <<SQL-Traverse,`TRAVERSE`>> as it is faster in some cases.
 
 For example, this query traverses the `follow` relationship on Twitter accounts, getting the second level of friendship:
 
@@ -129,7 +130,7 @@ ArcadeDB> SELECT FROM (TRAVERSE out('follow') FROM TwitterAccounts MAXDEPTH 2 )
           WHERE $depth = 2
 ----
 
-But, you could also express this same query using <<SQL-Query,`SELECT`>> operation, in a way that is also shorter and faster:
+But, you could also express this same query using <<SQL-Select,`SELECT`>> operation, in a way that is also shorter and faster:
 
 [source,sql]
 ----

--- a/src/main/asciidoc/sql/SQL-Truncate-Bucket.adoc
+++ b/src/main/asciidoc/sql/SQL-Truncate-Bucket.adoc
@@ -1,3 +1,4 @@
+[[SQL-Truncate-Bucket]]
 [discrete]
 
 === SQL - `TRUNCATE BUCKET`

--- a/src/main/asciidoc/sql/SQL-Truncate-Type.adoc
+++ b/src/main/asciidoc/sql/SQL-Truncate-Type.adoc
@@ -1,3 +1,4 @@
+[[SQL-Truncate-Type]]
 [discrete]
 
 === SQL - `TRUNCATE TYPE`

--- a/src/main/asciidoc/sql/SQL-Update.adoc
+++ b/src/main/asciidoc/sql/SQL-Update.adoc
@@ -1,3 +1,4 @@
+[[SQL-Update]]
 [discrete]
 === SQL - `UPDATE`
 
@@ -24,12 +25,12 @@ UPDATE <type>|BUCKET:<bucket>|<recordID>
 * *`MERGE`* Merges the record content with a JSON document.
 * *`UPSERT`* Updates a record if it exists or inserts a new record if it doesn't. This avoids the need to execute two commands, (one for each condition, inserting and updating).
 
-`UPSERT` requires a <<_filtering,`WHERE`>> clause and a type target. There are further limitations on `UPSERT`, explained below.
+`UPSERT` requires a <<Filtering,`WHERE`>> clause and a type target. There are further limitations on `UPSERT`, explained below.
 - *`RETURN`* Specifies an expression to return instead of the record and what to do with the result-set returned by the expression. The available return operators are:
  - `COUNT` Returns the number of updated records. This is the default return operator.
  - `BEFORE` Returns the records before the update.
  - `AFTER` Return the records after the update.
-- <<_filtering,`WHERE`>>
+- <<Filtering,`WHERE`>>
 - `LIMIT` Defines the maximum number of records to update.
 - `TIMEOUT` Defines the time you want to allow the update run before it times out.
 
@@ -117,11 +118,11 @@ ArcadeDB> UPDATE ♯7:0 SET gender='male' RETURN AFTER $current.exclude("really_
 
 In the event that a single field is returned, ArcadeDB wraps the result-set in a record storing the value in the field `result`. This avoids introducing a new serialization, as there is no primitive values collection serialization in the binary protocol. Additionally, it provides useful fields like `version` and `rid` from the original record in corresponding fields. The new syntax allows for optimization of client-server network traffic.
 
-For more information on SQL syntax, see <<_sql-select,`SELECT`>>.
+For more information on SQL syntax, see <<SQL-Select,`SELECT`>>.
 
 *Limitations of the `UPSERT` Clause*
 
-The `UPSERT` clause only guarantees atomicity when you use a `UNIQUE` index and perform the look-up on the index through the <<SQL-Where,`WHERE`>> condition.
+The `UPSERT` clause only guarantees atomicity when you use a `UNIQUE` index and perform the look-up on the index through the <<Filtering,`WHERE`>> condition.
 
 ----
 ArcadeDB> UPDATE Client SET id = 23 UPSERT WHERE id = 23

--- a/src/main/asciidoc/sql/SQL-Where.adoc
+++ b/src/main/asciidoc/sql/SQL-Where.adoc
@@ -28,7 +28,7 @@ And `item` can be:
 |any()|Represents any field of the Document. The condition is true if ANY of the fields matches the condition|where _any()_ like 'L%'
 |all()|Represents all the fields of the Document. The condition is true if ALL the fields match the condition|where _all()_ is null
 | <<SQL-Functions,Functions>> |Any <<SQL-Functions,Functions>> between the defined ones|where distance(x, y, 52.20472, 0.14056 ) &lt;= 30
-|<<_filtering,$variable>>|Context variable prefixed with $|where $depth &lt;= 3
+|<<Filtering,$variable>>|Context variable prefixed with $|where $depth &lt;= 3
 |===
 
 [discrete]
@@ -116,12 +116,12 @@ ArcadeDB supports variables managed in the context of the command/query. By defa
 [%header,cols=3]
 |===
 |Name |Description |Command(s)
-|$parent|Get the parent context from a sub-query. Example: select from V let $type = ( traverse * from $parent.$current.children )|<<_sql-select,SQL-Query>> and <<_sql-traverse,SQL-Traverse>>
-|$current|Current record to use in sub-queries to refer from the parent's variable|<<_sql-select,SQL-Query>> and <<_sql-traverse,SQL-Traverse>>
-|$depth|The current depth of nesting|<<_sql-traverse,SQL-Traverse>>
-|$path|The string representation of the current path. Example: #6:0.in.#5:0#.out. You can also display it with -&gt; select $path from (traverse * from V)|<<_sql__traverse,SQL-Traverse>>
-|$stack|The List of operation in the stack. Use it to access to the history of the traversal|<<_sql-traverse,SQL-Traverse>>|1.1.0|
-|$history|The set of all the records traversed as a Set&lt;ORID&gt;|<<_sql-traverse,TRAVERSE>>
+|$parent|Get the parent context from a sub-query. Example: select from V let $type = ( traverse * from $parent.$current.children )|<<SQL-Select,SQL-Query>> and <<SQL-Traverse,SQL-Traverse>>
+|$current|Current record to use in sub-queries to refer from the parent's variable|<<SQL-Select,SQL-Query>> and <<SQL-Traverse,SQL-Traverse>>
+|$depth|The current depth of nesting|<<SQL-Traverse,SQL-Traverse>>
+|$path|The string representation of the current path. Example: #6:0.in.#5:0#.out. You can also display it with -&gt; select $path from (traverse * from V)|<<SQL-Traverse,SQL-Traverse>>
+|$stack|The List of operation in the stack. Use it to access to the history of the traversal|<<SQL-Traverse,SQL-Traverse>>|1.1.0|
+|$history|The set of all the records traversed as a Set&lt;ORID&gt;|<<SQL-Traverse,TRAVERSE>>
 |===
 
 To set custom variable use the &lt;&lt;LET,SQL-Select-Let) keyword.

--- a/src/main/asciidoc/sql/chapter.adoc
+++ b/src/main/asciidoc/sql/chapter.adoc
@@ -10,15 +10,15 @@ image:../images/edit.png[link="https://github.com/ArcadeData/arcadedb-docs/blob/
 [%header,cols=4]
 |===
 | CRUD | Graph | Schema & Indexes | Database
-| <<_sql-select,SELECT>> | <<_sql-create-vertex,CREATE VERTEX>> | <<_sql-create-type,CREATE TYPE>> | <<_sql-create-bucket,CREATE BUCKET>>
-| <<_sql-insert,INSERT>> | <<_sql-create-edge,CREATE EDGE>> |<<_sql-alter-type,ALTER TYPE>> | <<_sql-alter-bucket,ALTER BUCKET>>
-| <<_sql-update,UPDATE>> | <<_sql-match,MATCH>>  |<<_sql-drop-type,DROP TYPE>> | <<_sql-drop-bucket,DROP BUCKET>>
-| <<_sql-delete,DELETE>> |  | <<_sql-create-property,CREATE PROPERTY>> | <<_sql-alter-database,ALTER DATABASE>>
-| <<_sql-traverse,TRAVERSE>> |  |  <<_sql-alter-property,ALTER PROPERTY>> | <<_console-command-create-database,CREATE DATABASE (console only)>>
-| <<_sql-truncate-type,TRUNCATE TYPE>> |  | <<_sql-drop-property,DROP PROPERTY>> | <<_console-command-drop-database,DROP DATABASE (console only)>>
-| <<_sql-truncate-bucket,TRUNCATE BUCKET>> | | <<_sql-create-index,CREATE INDEX>> |  <<_sql-backup-database,BACKUP DATABASE>>
-| | | <<_sql-rebuild-index,REBUILD INDEX>>  |  <<_sql-import-database,IMPORT DATABASE>>
-| | | <<_sql-drop-index,DROP INDEX>>  |  <<_sql-export-database,EXPORT DATABASE>>
+| <<SQL-Select,SELECT>> | <<SQL-Create-Vertex,CREATE VERTEX>> | <<SQL-Create-Type,CREATE TYPE>> | <<SQL-Create-Bucket,CREATE BUCKET>>
+| <<SQL-Insert,INSERT>> | <<SQL-Create-Edge,CREATE EDGE>> |<<SQL-Alter-Type,ALTER TYPE>> | ALTER BUCKET _not implemented_
+| <<SQL-Update,UPDATE>> | <<SQL-Match,MATCH>>  |<<SQL-Drop-Type,DROP TYPE>> | <<SQL-Drop-Bucket,DROP BUCKET>>
+| <<SQL-Delete,DELETE>> |  | <<SQL-Create-Property,CREATE PROPERTY>> | <<SQL-Alter-Database,ALTER DATABASE>>
+| <<SQL-Traverse,TRAVERSE>> |  |  <<SQL-Alter-Property,ALTER PROPERTY>> | <<_console-command-create-database,CREATE DATABASE (console only)>>
+| <<SQL-Truncate-Type,TRUNCATE TYPE>> |  | <<SQL-Drop-Property,DROP PROPERTY>> | <<_console-command-drop-database,DROP DATABASE (console only)>>
+| <<SQL-Truncate-Bucket,TRUNCATE BUCKET>> | | <<SQL-Create-Index,CREATE INDEX>> |  <<SQL-Backup-Database,BACKUP DATABASE>>
+| | | <<_sql-rebuild-index,REBUILD INDEX>>  |  <<SQL-Import-Database,IMPORT DATABASE>>
+| | | <<SQL-Drop-Index,DROP INDEX>>  |  <<_sql-export-database,EXPORT DATABASE>>
 | | |  | <<_sql-check-database,CHECK DATABASE>>
 | | |  | <<_sql-align-database,ALIGN DATABASE>>
 |===


### PR DESCRIPTION
* _sql-alter-database -> SQL-Alter-Database
* _sql-alter-property -> SQL-Alter-Property
* _sql-alter-type -> SQL-Alter-Type
* _sql-backup-database -> SQL-Backup-Database
* _sql-create-bucket -> SQL-Create-Bucket
* _sql-create-edge -> SQL-Create-Edge
* _sql-create-index -> SQL-Create-Index
* _sql-create-property -> SQL-Create-Property
* _sql-create-type -> SQL-Create-Type
* _sql-delete -> SQL-Delete
* _sql-drop-bucket -> SQL-Drop-Bucket
* _sql-drop-index -> SQL-Drop-Index
* _sql-drop-property -> SQL-Drop-Property
* _sql-drop-type -> SQL-Drop-Type
* _sql-explain -> SQL-Explain
* _sql-import-database -> 'SQL-Import-Database'
* _sql-insert -> 'SQL-Insert'
* _sql-match -> SQL-Match
* _sql-profile -> SQL-Profile
* _sql-select -> 'SQL-Select'
* _sql-traverse -> SQL-Traverse
* _sql-truncate-bucket -> SQL-Truncate-Bucket
* _sql-truncate-type -> SQL-Truncate-Type
* _sql-update -> SQL-Update

other noteworthy changes to other sections:

* fixes EXPLAIN & PROFILE links, and adds an EXPLAIN link from SQL-Select-Execution.adoc

* fixes links to UNWIND from SQL-Select.adoc, points to "Unwinding" section in SQL-Select.adoc

* _pagination -> SQL-Pagination, and fixes related links throughout

* _projections -> SQL-Projections, and fixes links

* fixes <<SQL-Query,SELECT>> and <SQL-Query,SQL Query>> links to instead reference SQL-Select

* fixes broken link in SQL-Alter-Property to point to SQL-Create-Property

* changes references to 'SQL-Where' and '_filtering' to 'Filtering' to match current name of SQL-Where.adoc

* fixes broken link 'ArcadeDB SQL dialect' to point to 'SQL-Syntax' in the Appendix

* adds _not implemented_ note and unlinks ALTER BUCKET statement, there is no existing documentation and the source throws UnsupportedOperationException: https://github.com/ArcadeData/arcadedb/blob/39eacc45d8e65ac365c1698bb739831660e15161/engine/src/main/java/com/arcadedb/query/sql/parser/AlterBucketStatement.java